### PR TITLE
Fix incorrect index computation

### DIFF
--- a/MovingAverageFloat.h
+++ b/MovingAverageFloat.h
@@ -81,7 +81,7 @@ float MovingAverageFloat<N>::add(float value) {
   } else {
     _sum = _sum - _buffer[_next] + value;
     _buffer[_next] = value;
-    _next = (_next + 1) & (N - 1);
+    _next = (_next + 1) % N;
   }
 
   _result = _sum / static_cast<float>(N);


### PR DESCRIPTION
**This PR fixes index computation for the next value to insert.**

The original version just works for power-of-two filter sizes `N`. The fix allows for arbitrary integer sizes.

- closes #1